### PR TITLE
Added goal update assertion in plan history

### DIFF
--- a/page-objects/pages-common.ts
+++ b/page-objects/pages-common.ts
@@ -1,3 +1,5 @@
 export const DEFAULT_CLICK_OPTIONS = { delay: 1000 };
 
 export const PK_WITH_COMPLETED_SAN = '787703'
+
+export const GOAL_STATUS_UPDATE = 'Goal updated on 24 February 2025 by Fannie Lehner'

--- a/page-objects/pages-common.ts
+++ b/page-objects/pages-common.ts
@@ -2,6 +2,4 @@ export const DEFAULT_CLICK_OPTIONS = { delay: 1000 };
 
 export const PK_WITH_COMPLETED_SAN = '787703'
 
-export const GOAL_STATUS_UPDATE = 'Goal updated on 24 February 2025 by Fannie Lehner'
-
-export const GOAL_CREATION_UPDATE = 'Plan created on 24 February 2025 by Dylan Hettinger'
+export const GOAL_CREATED_DATA = 'Plan created on 24 February 2025 by Dylan Hettinger'

--- a/page-objects/pages-common.ts
+++ b/page-objects/pages-common.ts
@@ -3,3 +3,5 @@ export const DEFAULT_CLICK_OPTIONS = { delay: 1000 };
 export const PK_WITH_COMPLETED_SAN = '787703'
 
 export const GOAL_STATUS_UPDATE = 'Goal updated on 24 February 2025 by Fannie Lehner'
+
+export const GOAL_CREATION_UPDATE = 'Plan created on 24 February 2025 by Dylan Hettinger'

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { GOAL_CREATION_UPDATE, GOAL_STATUS_UPDATE } from './pages-common';
+import { GOAL_CREATED_DATA } from './pages-common';
 
 const { chromium } = require('playwright');
 
@@ -295,13 +295,8 @@ export class SentencePlanPage {
         await newTabGlobal!.getByRole('button', { name: 'Save goal and steps' }).click();
     }
 
-    async checkPlanHistoryDateAndPracticionerUpdateIsUnique() {
-        await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_STATUS_UPDATE }).getByRole('strong'))
-            .toHaveCount(1);
-    }
-
     async checkPlanCreationUpdateIsUnique() {
-        await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_CREATION_UPDATE }).getByRole('strong'))
+        await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_CREATED_DATA }).getByRole('strong'))
             .toHaveCount(1);
     }
 }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -2,6 +2,14 @@ import { expect, Locator, Page } from '@playwright/test';
 import { GOAL_CREATED_DATA } from './pages-common';
 
 const { chromium } = require('playwright');
+const gettodayDateFormatted = (): string => {
+    const today = new Date();
+    return today.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric'
+    });
+}
 
 let newTabGlobal: Page | null = null;
 
@@ -297,6 +305,12 @@ export class SentencePlanPage {
 
     async checkPlanCreationUpdateIsUnique() {
         await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_CREATED_DATA }).getByRole('strong'))
+            .toHaveCount(1);
+    }
+
+    async checkPlanCreationIsNotOverwritten() {
+        const todayDate = gettodayDateFormatted();
+        await expect(newTabGlobal!.locator('p').filter({ hasText: 'Plan created on ' + todayDate }).getByRole('strong'))
             .toHaveCount(1);
     }
 }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -261,7 +261,6 @@ export class SentencePlanPage {
         await newTabGlobal!.locator('a.moj-primary-navigation__link').first().click();
     }
 
-
     async clickPlanHistoryTopNavLink() {
         await newTabGlobal!.getByRole('link', { name: 'Plan history', exact: true }).click();
     }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
+import { GOAL_STATUS_UPDATE } from './pages-common';
 
 const { chromium } = require('playwright');
 
@@ -150,6 +151,10 @@ export class SentencePlanPage {
         await expect(newTabGlobal!).toHaveTitle('Change goal - Sentence plan');
     }
 
+    async checkUpdateStepsPageTitle() {
+        await expect(newTabGlobal!).toHaveTitle('Update goal and steps - Sentence plan');
+    }
+
     async checkAddStepsToGoalPageTitle() {
         await expect(newTabGlobal!).toHaveTitle('Add or change steps - Sentence plan');
     }
@@ -250,5 +255,49 @@ export class SentencePlanPage {
     async checkNumberOfFutureGoalsIsCorrect() {
         await expect(newTabGlobal!.getByRole('link', { name: 'Future goals (1)' }))
             .toBeVisible();
+    }
+
+    async clickPlanTopNavLink() {
+        await newTabGlobal!.locator('a.moj-primary-navigation__link').first().click();
+    }
+
+
+    async clickPlanHistoryTopNavLink() {
+        await newTabGlobal!.getByRole('link', { name: 'Plan history', exact: true }).click();
+    }
+
+    async clickUpdateLink() {
+        await newTabGlobal!.getByRole('link', { name: 'Update   (test goal)' }).click();
+    }
+
+    async updateStepStatustoInProgress() {
+        await newTabGlobal!.getByRole('row', { name: 'Probation practitioner test 1' }).getByLabel('Status').selectOption('IN_PROGRESS');
+    }
+
+    async checkStepStatusIsSetToInProgress() {
+        await expect(newTabGlobal!.getByRole('row', { name: 'Probation practitioner test 1' }).getByRole('strong'))
+            .toHaveText('In progress');
+    }
+
+    async updateStepStatusBackToNotStarted() {
+        await newTabGlobal!.getByRole('cell', { name: 'In progress' }).getByLabel('Status').selectOption('NOT_STARTED');
+    }
+
+    async checkStepStatusBackToNotStarted() {
+        await expect(newTabGlobal!.getByRole('row', { name: 'Probation practitioner test 1' }).getByRole('strong'))
+            .toHaveText('Not started');
+    }
+
+    async addNotesAboutStepUpdate() {
+        await newTabGlobal!.getByLabel('Add notes about progress (').fill('Status update test note');
+    }
+
+    async clickSaveGoalAndStepsButton() {
+        await newTabGlobal!.getByRole('button', { name: 'Save goal and steps' }).click();
+    }
+
+    async assertPlanHistoryDateAndPracticionerUpdate() {
+        await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_STATUS_UPDATE }).getByRole('strong'))
+            .toHaveCount(1);
     }
 }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -311,6 +311,6 @@ export class SentencePlanPage {
     async checkPlanCreationIsNotOverwritten() {
         const todayDate = gettodayDateFormatted();
         await expect(newTabGlobal!.locator('p').filter({ hasText: 'Plan created on ' + todayDate }).getByRole('strong'))
-            .toHaveCount(1);
+            .toHaveCount(0);
     }
 }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -2,7 +2,7 @@ import { expect, Locator, Page } from '@playwright/test';
 import { GOAL_CREATED_DATA } from './pages-common';
 
 const { chromium } = require('playwright');
-const gettodayDateFormatted = (): string => {
+const getTodayDateFormatted = (): string => {
     const today = new Date();
     return today.toLocaleDateString('en-GB', {
         day: 'numeric',
@@ -309,7 +309,7 @@ export class SentencePlanPage {
     }
 
     async checkPlanCreationIsNotOverwritten() {
-        const todayDate = gettodayDateFormatted();
+        const todayDate = getTodayDateFormatted();
         await expect(newTabGlobal!.locator('p').filter({ hasText: 'Plan created on ' + todayDate }).getByRole('strong'))
             .toHaveCount(0);
     }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { GOAL_STATUS_UPDATE } from './pages-common';
+import { GOAL_CREATION_UPDATE, GOAL_STATUS_UPDATE } from './pages-common';
 
 const { chromium } = require('playwright');
 
@@ -295,8 +295,13 @@ export class SentencePlanPage {
         await newTabGlobal!.getByRole('button', { name: 'Save goal and steps' }).click();
     }
 
-    async assertPlanHistoryDateAndPracticionerUpdate() {
+    async checkPlanHistoryDateAndPracticionerUpdateIsUnique() {
         await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_STATUS_UPDATE }).getByRole('strong'))
+            .toHaveCount(1);
+    }
+
+    async checkPlanCreationUpdateIsUnique() {
+        await expect(newTabGlobal!.locator('p').filter({ hasText: GOAL_CREATION_UPDATE }).getByRole('strong'))
             .toHaveCount(1);
     }
 }

--- a/tests/06.userViewsAssessmentInfoComplete.spec.ts
+++ b/tests/06.userViewsAssessmentInfoComplete.spec.ts
@@ -2,6 +2,8 @@ import { test } from '@playwright/test';
 import { StubHomePage } from '../page-objects/stub-home-page';
 import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
 
+/* Note: this test feature will fail if the test data is wiped. 
+It relies on pre-existing PK with a completed SAN assessment. */
 test('User views assessment info when they have completed that assessment', async ({ page }) => {
 
   const stubHomePage = new StubHomePage(page);

--- a/tests/06.userViewsAssessmentInfoComplete.spec.ts
+++ b/tests/06.userViewsAssessmentInfoComplete.spec.ts
@@ -13,7 +13,7 @@ test('User views assessment info when they have completed that assessment', asyn
   // Check the title of the page is correct
   await stubHomePage.checkPageTitle();
 
-  // Set up accomodation criminogenic needs No answers
+  // Paste PK of existing user
   await stubHomePage.fillInPkNumberOfCompletedAssessment()
 
   // Select sentence plan

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -2,7 +2,7 @@ import { test } from '@playwright/test';
 import { StubHomePage } from '../page-objects/stub-home-page';
 import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
 
-test('User views assessment info when they have completed that assessment', async ({ page }) => {
+test('User updates their step status and checks plan history', async ({ page }) => {
 
   const stubHomePage = new StubHomePage(page);
   const sentencePlanPage = new SentencePlanPage(page);

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -2,6 +2,8 @@ import { test } from '@playwright/test';
 import { StubHomePage } from '../page-objects/stub-home-page';
 import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
 
+/* Note: this test feature will fail if the test data is wiped. 
+It relies on pre-existing PK with a completed SAN assessment. */
 test('User updates their step status and checks plan history', async ({ page }) => {
 
   const stubHomePage = new StubHomePage(page);

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -40,6 +40,7 @@ test('User views assessment info when they have completed that assessment', asyn
   // Check information from plan history page
   await sentencePlanPage.clickPlanHistoryTopNavLink();
   await sentencePlanPage.checkPlanCreationUpdateIsUnique();
+  await sentencePlanPage.checkPlanCreationIsNotOverwritten();
   console.log('Update information from plan history verified');
 
   // Revert step status back to not started

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -1,0 +1,54 @@
+import { test } from '@playwright/test';
+import { StubHomePage } from '../page-objects/stub-home-page';
+import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
+
+test('User views assessment info when they have completed that assessment', async ({ page }) => {
+
+  const stubHomePage = new StubHomePage(page);
+  const sentencePlanPage = new SentencePlanPage(page);
+
+  // Navigate to the stub home page
+  await stubHomePage.goto();
+
+  // Check the title of the page is correct
+  await stubHomePage.checkPageTitle();
+
+  // Set up accomodation criminogenic needs No answers
+  await stubHomePage.fillInPkNumberOfCompletedAssessment()
+
+  // Select sentence plan
+  await stubHomePage.selectSentencePlan();
+
+  // Click create handover button
+  await stubHomePage.clickCreateHandoverButton();
+
+  // Click open button
+  await stubHomePage.clickOpenButton();
+
+  // Check the page title is correct
+  await sentencePlanPage.checkPageTitle();
+
+  // Change step status and add notes
+  await sentencePlanPage.clickUpdateLink();
+  await sentencePlanPage.checkUpdateStepsPageTitle();
+  await sentencePlanPage.updateStepStatustoInProgress();
+  await sentencePlanPage.addNotesAboutStepUpdate();
+  await sentencePlanPage.clickSaveGoalAndStepsButton();
+  await sentencePlanPage.checkStepStatusIsSetToInProgress();
+  console.log('Goal step status updated to in progress');
+
+  // Check information from plan history page
+  await sentencePlanPage.clickPlanHistoryTopNavLink();
+  await sentencePlanPage.assertPlanHistoryDateAndPracticionerUpdate();
+  console.log('Update information from plan history verified');
+
+  // Revert step status back to not started
+  await sentencePlanPage.clickPlanTopNavLink();
+  await sentencePlanPage.clickUpdateLink();
+  await sentencePlanPage.checkUpdateStepsPageTitle();
+  await sentencePlanPage.updateStepStatusBackToNotStarted();
+  await sentencePlanPage.addNotesAboutStepUpdate();
+  await sentencePlanPage.clickSaveGoalAndStepsButton();
+  await sentencePlanPage.checkStepStatusBackToNotStarted();
+  console.log('Goal step status updated back to not started');
+});

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -13,7 +13,7 @@ test('User views assessment info when they have completed that assessment', asyn
   // Check the title of the page is correct
   await stubHomePage.checkPageTitle();
 
-  // Set up accomodation criminogenic needs No answers
+  // Paste PK of existing user
   await stubHomePage.fillInPkNumberOfCompletedAssessment()
 
   // Select sentence plan

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -39,7 +39,6 @@ test('User views assessment info when they have completed that assessment', asyn
 
   // Check information from plan history page
   await sentencePlanPage.clickPlanHistoryTopNavLink();
-  await sentencePlanPage.checkPlanHistoryDateAndPracticionerUpdateIsUnique();
   await sentencePlanPage.checkPlanCreationUpdateIsUnique();
   console.log('Update information from plan history verified');
 

--- a/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
+++ b/tests/07.userUpdatesGoalAndViewsHistory.spec.ts
@@ -39,7 +39,8 @@ test('User views assessment info when they have completed that assessment', asyn
 
   // Check information from plan history page
   await sentencePlanPage.clickPlanHistoryTopNavLink();
-  await sentencePlanPage.assertPlanHistoryDateAndPracticionerUpdate();
+  await sentencePlanPage.checkPlanHistoryDateAndPracticionerUpdateIsUnique();
+  await sentencePlanPage.checkPlanCreationUpdateIsUnique();
   console.log('Update information from plan history verified');
 
   // Revert step status back to not started


### PR DESCRIPTION
Added a test feature for a scenario where an existing user updates a step status and asserts the date/practitioner values are not duplicated.