### PR TITLE
Added further tests on About page

### DIFF
--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -242,6 +242,10 @@ export class SentencePlanPage {
         await expect(newTabGlobal!).toHaveTitle('Plan - Sentence plan');
     }
 
+    async checkCreateAGoalPageTitle() {
+        await expect(newTabGlobal!).toHaveTitle('Create a goal - Sentence plan');
+    }
+
     async clickSaveWithoutStepsButton() {
         await newTabGlobal!.getByRole('button', { name: 'Save without steps' }).click();
     }
@@ -334,18 +338,32 @@ export class SentencePlanPage {
             .toHaveCount(0);
     }
 
+    async clickShowAllSectionsAccordion() {
+        await newTabGlobal!.locator('#assessment-accordion-highScoring').getByRole('button', { name: 'Show all sections' })
+            .click();
+    }
+
+    async clickCreateAGoalLinkFromWithinSection() {
+        await newTabGlobal!.locator('#assessment-accordion-highScoring-content-1 > p.goal-link > a')
+            .click();
+    }
+
+    async clickBackButtonFromCreateGoalPage() {
+        await newTabGlobal!.getByRole('link', { name: 'Back' }).click();
+    }
+
     async checkSectionsAreListedAsIncompleteInformation() {
         const missingInfoAccordion = newTabGlobal!.locator('#assessment-accordion-incompleteAreas')
-        await expect (missingInfoAccordion).toBeVisible();
-        const missingInfoSections =[
-          newTabGlobal!.getByLabel('Accommodation'),
-          newTabGlobal!.getByLabel('Alcohol use'),
-          newTabGlobal!.getByLabel('Drug use'),
-          newTabGlobal!.getByLabel('Employment and education'),
-          newTabGlobal!.getByLabel('Finances'),
-          newTabGlobal!.getByLabel('Health and wellbeing'),
-          newTabGlobal!.getByLabel('Personal relationships and'),
-          newTabGlobal!.getByLabel('Thinking, behaviours and')
+        await expect(missingInfoAccordion).toBeVisible();
+        const missingInfoSections = [
+            newTabGlobal!.getByLabel('Accommodation'),
+            newTabGlobal!.getByLabel('Alcohol use'),
+            newTabGlobal!.getByLabel('Drug use'),
+            newTabGlobal!.getByLabel('Employment and education'),
+            newTabGlobal!.getByLabel('Finances'),
+            newTabGlobal!.getByLabel('Health and wellbeing'),
+            newTabGlobal!.getByLabel('Personal relationships and'),
+            newTabGlobal!.getByLabel('Thinking, behaviours and')
         ];
         for (const locator of missingInfoSections) {
             await expect(locator).toBeVisible();
@@ -354,8 +372,8 @@ export class SentencePlanPage {
 
     async checkNoInfoAvailableDisplays() {
         await newTabGlobal!.locator('#accommodation > div.govuk-accordion__section-header > h3 > button').click();
-        await expect (newTabGlobal!.getByText('No information is available yet'))
-        .toBeVisible();
-        
+        await expect(newTabGlobal!.getByText('No information is available yet'))
+            .toBeVisible();
+
     }
 }

--- a/tests/08.userViewsAboutPageCompleteSan.spec.ts
+++ b/tests/08.userViewsAboutPageCompleteSan.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test';
 import { StubHomePage } from '../page-objects/stub-home-page';
 import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
+import { Accessibility } from '../page-objects/accessibility';
 
 /* Note: this test feature will fail if the test data is wiped. 
 It relies on pre-existing PK with a completed SAN assessment. */
@@ -8,6 +9,7 @@ test('User views about page when they have completed SAN assessment', async ({ p
 
   const stubHomePage = new StubHomePage(page);
   const sentencePlanPage = new SentencePlanPage(page);
+  const accessibility = new Accessibility(page);
 
   // Navigate to the stub home page
   await stubHomePage.goto();
@@ -37,4 +39,19 @@ test('User views about page when they have completed SAN assessment', async ({ p
   // Check no banner displays
   await sentencePlanPage.checkBannerDoesntDisplayForCompleteAssessment();
   console.log('About page complete assessment - info verified');
+
+  // Check page has no accessiblity violations
+  await accessibility.shouldHaveNoAccessibilityViolations();
+
+  // Click show all sections accordion and check there are still no accessibility violations
+  await sentencePlanPage.clickShowAllSectionsAccordion();
+  await accessibility.shouldHaveNoAccessibilityViolations();
+
+  // Click create a goal from section
+  await sentencePlanPage.clickCreateAGoalLinkFromWithinSection();
+  await sentencePlanPage.checkCreateAGoalPageTitle();
+
+  // Back out from page and ensure user is back on About page
+  await sentencePlanPage.clickBackButtonFromCreateGoalPage();
+  await sentencePlanPage.checkAboutPageTitle();
 });


### PR DESCRIPTION
This ticket is to add more tests covering the About page:

- More accessibility scans (accordion ARIA which used to fail, fixed on 7/03/25)
- Backing out from creating a goal from about page which used to incorrectly take the user back to their plan