### PR TITLE
Ai 74 integration tests add a first san sp test feature without an oasys step

### DIFF
--- a/data/incompleteSanData.json
+++ b/data/incompleteSanData.json
@@ -1,0 +1,157 @@
+{
+    "oasys-assessment-pk": "450470",
+    "subject": {
+      "given-name": "Jessyca",
+      "family-name": "Volkman",
+      "gender": "9",
+      "date-of-birth": "1937-04-29",
+      "sexually-motivated-offence-history": "",
+      "location": "COMMUNITY",
+      "crn": "X778160",
+      "pnc": "01/72057888A"
+    },
+    "user": {
+      "identifier": "OAStub-6ff8f2b9",
+      "display-name": "Kareem Toy",
+      "access-mode": "READ_WRITE"
+    },
+    "versions": {
+      "assessment-version": "",
+      "sentence-plan-version": ""
+    },
+    "accLinkedToHarm": {
+      "accLinkedToHarm": "NO"
+    },
+    "accLinkedToReoffending": {
+      "accLinkedToReoffending": "NO"
+    },
+    "accStrengths": {
+      "accStrengths": "NO"
+    },
+    "accOtherWeightedScore": {
+      "accOtherWeightedScore": "1"
+    },
+    "accThreshold": {
+      "accThreshold": "YES"
+    },
+    "eteLinkedToHarm": {
+      "eteLinkedToHarm": "YES"
+    },
+    "eteLinkedToReoffending": {
+      "eteLinkedToReoffending": "YES"
+    },
+    "eteStrengths": {
+      "eteStrengths": "YES"
+    },
+    "eteOtherWeightedScore": {
+      "eteOtherWeightedScore": "4"
+    },
+    "eteThreshold": {
+      "eteThreshold": "YES"
+    },
+    "financeLinkedToHarm": {
+      "financeLinkedToHarm": "NO"
+    },
+    "financeLinkedToReoffending": {
+      "financeLinkedToReoffending": "YES"
+    },
+    "financeStrengths": {
+      "financeStrengths": "NO"
+    },
+    "financeOtherWeightedScore": {
+      "financeOtherWeightedScore": "N/A"
+    },
+    "financeThreshold": {
+      "financeThreshold": "N/A"
+    },
+    "drugLinkedToHarm": {
+      "drugLinkedToHarm": "YES"
+    },
+    "drugLinkedToReoffending": {
+      "drugLinkedToReoffending": "YES"
+    },
+    "drugStrengths": {
+      "drugStrengths": "YES"
+    },
+    "drugOtherWeightedScore": {
+      "drugOtherWeightedScore": "3"
+    },
+    "drugThreshold": {
+      "drugThreshold": "YES"
+    },
+    "alcoholLinkedToHarm": {
+      "alcoholLinkedToHarm": "YES"
+    },
+    "alcoholLinkedToReoffending": {
+      "alcoholLinkedToReoffending": "NO"
+    },
+    "alcoholStrengths": {
+      "alcoholStrengths": "YES"
+    },
+    "alcoholOtherWeightedScore": {
+      "alcoholOtherWeightedScore": "1"
+    },
+    "alcoholThreshold": {
+      "alcoholThreshold": "NO"
+    },
+    "emoLinkedToHarm": {
+      "emoLinkedToHarm": "NO"
+    },
+    "emoLinkedToReoffending": {
+      "emoLinkedToReoffending": "NO"
+    },
+    "emoStrengths": {
+      "emoStrengths": "NULL"
+    },
+    "emoOtherWeightedScore": {
+      "emoOtherWeightedScore": "N/A"
+    },
+    "emoThreshold": {
+      "emoThreshold": "N/A"
+    },
+    "relLinkedToHarm": {
+      "relLinkedToHarm": "NO"
+    },
+    "relLinkedToReoffending": {
+      "relLinkedToReoffending": "YES"
+    },
+    "relStrengths": {
+      "relStrengths": "NO"
+    },
+    "relOtherWeightedScore": {
+      "relOtherWeightedScore": "5"
+    },
+    "relThreshold": {
+      "relThreshold": "YES"
+    },
+    "thinkLinkedToHarm": {
+      "thinkLinkedToHarm": "NO"
+    },
+    "thinkLinkedToReoffending": {
+      "thinkLinkedToReoffending": "NULL"
+    },
+    "thinkStrengths": {
+      "thinkStrengths": "NULL"
+    },
+    "thinkOtherWeightedScore": {
+      "thinkOtherWeightedScore": "6"
+    },
+    "thinkThreshold": {
+      "thinkThreshold": "YES"
+    },
+    "lifestyleLinkedToHarm": {
+      "lifestyleLinkedToHarm": "N/A"
+    },
+    "lifestyleLinkedToReoffending": {
+      "lifestyleLinkedToReoffending": "N/A"
+    },
+    "lifestyleStrengths": {
+      "lifestyleStrengths": "N/A"
+    },
+    "lifestyleOtherWeightedScore": {
+      "lifestyleOtherWeightedScore": ""
+    },
+    "lifestyleThreshold": {
+      "lifestyleThreshold": "YES"
+    }
+  }

--- a/page-objects/pages-common.ts
+++ b/page-objects/pages-common.ts
@@ -3,3 +3,7 @@ export const DEFAULT_CLICK_OPTIONS = { delay: 1000 };
 export const PK_WITH_COMPLETED_SAN = '787703'
 
 export const GOAL_CREATED_DATA = 'Plan created on 24 February 2025 by Dylan Hettinger'
+
+export const PK_WITH_INCOMPLETE_SAN = '450470'
+
+export const SP_TEST_ENV_LINK = 'https://sentence-plan-test.hmpps.service.justice.gov.uk/plan'

--- a/page-objects/sentence-plan-page-from-san-page.ts
+++ b/page-objects/sentence-plan-page-from-san-page.ts
@@ -1,0 +1,36 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { SP_TEST_ENV_LINK } from './pages-common';
+
+let newTabGlobal: Page | null = null;
+
+export class SentencePlanfromSanPage {
+    constructor(
+        private page: Page,
+    ) { }
+
+    async checkPageTitle() {
+        const context = this.page.context();
+        const pages = context.pages();
+        const latestPage = pages[pages.length - 1];
+        await latestPage.bringToFront();
+        //wait for Load 
+        await latestPage.waitForLoadState();
+        newTabGlobal = latestPage;
+        await expect(latestPage).toHaveTitle('Plan - Sentence plan');
+    }
+
+    async navigateToSPLink() {
+        await newTabGlobal!.goto(SP_TEST_ENV_LINK);
+    }
+
+    async clickAboutPageAfterNavigatingToSPWithoutOasysStep() {
+        //const newPagePromise = this.page.waitForEvent('load');
+        //const newPage = await newPagePromise;
+        //wait for Load 
+        //await newPage.waitForLoadState();
+        //newTabGlobal2 = newPage;
+        const aboutLink = await newTabGlobal!.getByRole('link', { name: 'About', exact: false })
+        await aboutLink.waitFor({ state: 'visible' });
+        await aboutLink.click();
+    }
+}

--- a/page-objects/sentence-plan-page-from-san-page.ts
+++ b/page-objects/sentence-plan-page-from-san-page.ts
@@ -1,7 +1,35 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { SP_TEST_ENV_LINK } from './pages-common';
 
 let newTabGlobal: Page | null = null;
+
+//#region high scoring content details
+const highScoringInfoContentDetails = 
+    'This area is linked to RoSH (risk of serious harm)'
+    'Test yes serious harm'
+    'This area is linked to risk of reoffending'
+    'Test yes reoffending'
+    'Motivation to make changes in this area'
+    'wants to make changes but needs help.'
+    'There are strengths or protective factors related to this area'
+    'Test yes factors'
+    'Employment and education need score 4 out of 4'
+    'Create employment and education goal';
+//#endregion
+
+//#region low scoring content details
+const lowScoringInfoContentDetails = 
+'This area is not linked to RoSH (risk of serious harm)'
+'Test no serious harm'
+'This area is not linked to risk of reoffending'
+'Test no reoffending'
+'Motivation to make changes in this area'
+'has already made positive changes and wants to maintain them.'
+'There are no strengths or protective factors related to this area'
+'Test no factors'
+'Accommodation need score 1 out of 6'
+'Create accommodation goal';
+//#endregion
+
 
 export class SentencePlanfromSanPage {
     constructor(
@@ -19,18 +47,36 @@ export class SentencePlanfromSanPage {
         await expect(latestPage).toHaveTitle('Plan - Sentence plan');
     }
 
-    async navigateToSPLink() {
-        await newTabGlobal!.goto(SP_TEST_ENV_LINK);
-    }
-
     async clickAboutPageAfterNavigatingToSPWithoutOasysStep() {
-        //const newPagePromise = this.page.waitForEvent('load');
-        //const newPage = await newPagePromise;
-        //wait for Load 
-        //await newPage.waitForLoadState();
-        //newTabGlobal2 = newPage;
         const aboutLink = await newTabGlobal!.getByRole('link', { name: 'About', exact: false })
         await aboutLink.waitFor({ state: 'visible' });
         await aboutLink.click();
+    }
+
+    async checkAboutPageDisplaysCorrectInfoForIncompleteSan() {
+        // Check banner displays for incomplete assessment
+        const warning = await newTabGlobal!.getByLabel('Warning');
+        await expect (warning).toHaveCount(1);
+        const incompleteInfo = await newTabGlobal!.locator('h2.govuk-heading-m').first();
+        await expect (incompleteInfo).toHaveText('Some areas have incomplete information');
+
+        // Check high-scoring area displays the right info
+        const highScoringInfoAccordion = await newTabGlobal!.locator('#assessment-accordion-highScoring');
+        await expect (highScoringInfoAccordion).toContainText('Employment and education');
+        const employmentAndEducationSection = await newTabGlobal!.getByLabel('Employment and education ,');
+        await employmentAndEducationSection.click();
+        const highScoringInfoContent = await newTabGlobal!.locator('#assessment-accordion-highScoring-content-1');
+        const highScoringInfoText = await highScoringInfoContent.textContent();
+        await expect (highScoringInfoText).toContain(highScoringInfoContentDetails);
+        await employmentAndEducationSection.click();
+        
+        // Check low-scoring area displays the right info
+        const lowScoringInfoAccordion = await newTabGlobal!.locator('#assessment-accordion-lowScoring');
+        await expect (lowScoringInfoAccordion).toContainText('Accommodation');
+        const accommodationSection = await newTabGlobal!.getByLabel('Accommodation , , Show this')
+        await accommodationSection.click();
+        const lowScoringInfoContent = await newTabGlobal!.locator('#assessment-accordion-lowScoring-content-1');
+        const lowScoringInfoText = await lowScoringInfoContent.textContent();
+        await expect (lowScoringInfoText).toContain(lowScoringInfoContentDetails);
     }
 }

--- a/page-objects/sentence-plan-page-from-san-page.ts
+++ b/page-objects/sentence-plan-page-from-san-page.ts
@@ -3,22 +3,22 @@ import { expect, Locator, Page } from '@playwright/test';
 let newTabGlobal: Page | null = null;
 
 //#region high scoring content details
-const highScoringInfoContentDetails = 
+const highScoringInfoContentDetails =
     'This area is linked to RoSH (risk of serious harm)'
-    'Test yes serious harm'
-    'This area is linked to risk of reoffending'
-    'Test yes reoffending'
-    'Motivation to make changes in this area'
-    'wants to make changes but needs help.'
-    'There are strengths or protective factors related to this area'
-    'Test yes factors'
-    'Employment and education need score 4 out of 4'
-    'Create employment and education goal';
+'Test yes serious harm'
+'This area is linked to risk of reoffending'
+'Test yes reoffending'
+'Motivation to make changes in this area'
+'wants to make changes but needs help.'
+'There are strengths or protective factors related to this area'
+'Test yes factors'
+'Employment and education need score 4 out of 4'
+'Create employment and education goal';
 //#endregion
 
 //#region low scoring content details
-const lowScoringInfoContentDetails = 
-'This area is not linked to RoSH (risk of serious harm)'
+const lowScoringInfoContentDetails =
+    'This area is not linked to RoSH (risk of serious harm)'
 'Test no serious harm'
 'This area is not linked to risk of reoffending'
 'Test no reoffending'
@@ -56,27 +56,27 @@ export class SentencePlanfromSanPage {
     async checkAboutPageDisplaysCorrectInfoForIncompleteSan() {
         // Check banner displays for incomplete assessment
         const warning = await newTabGlobal!.getByLabel('Warning');
-        await expect (warning).toHaveCount(1);
+        await expect(warning).toHaveCount(1);
         const incompleteInfo = await newTabGlobal!.locator('h2.govuk-heading-m').first();
-        await expect (incompleteInfo).toHaveText('Some areas have incomplete information');
+        await expect(incompleteInfo).toHaveText('Some areas have incomplete information');
 
         // Check high-scoring area displays the right info
         const highScoringInfoAccordion = await newTabGlobal!.locator('#assessment-accordion-highScoring');
-        await expect (highScoringInfoAccordion).toContainText('Employment and education');
+        await expect(highScoringInfoAccordion).toContainText('Employment and education');
         const employmentAndEducationSection = await newTabGlobal!.getByLabel('Employment and education ,');
         await employmentAndEducationSection.click();
         const highScoringInfoContent = await newTabGlobal!.locator('#assessment-accordion-highScoring-content-1');
         const highScoringInfoText = await highScoringInfoContent.textContent();
-        await expect (highScoringInfoText).toContain(highScoringInfoContentDetails);
+        await expect(highScoringInfoText).toContain(highScoringInfoContentDetails);
         await employmentAndEducationSection.click();
-        
+
         // Check low-scoring area displays the right info
         const lowScoringInfoAccordion = await newTabGlobal!.locator('#assessment-accordion-lowScoring');
-        await expect (lowScoringInfoAccordion).toContainText('Accommodation');
+        await expect(lowScoringInfoAccordion).toContainText('Accommodation');
         const accommodationSection = await newTabGlobal!.getByLabel('Accommodation , , Show this')
         await accommodationSection.click();
         const lowScoringInfoContent = await newTabGlobal!.locator('#assessment-accordion-lowScoring-content-1');
         const lowScoringInfoText = await lowScoringInfoContent.textContent();
-        await expect (lowScoringInfoText).toContain(lowScoringInfoContentDetails);
+        await expect(lowScoringInfoText).toContain(lowScoringInfoContentDetails);
     }
 }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { GOAL_CREATED_DATA } from './pages-common';
+import { GOAL_CREATED_DATA, SP_TEST_ENV_LINK } from './pages-common';
 
 const { chromium } = require('playwright');
 const getTodayDateFormatted = (): string => {

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { GOAL_CREATED_DATA, SP_TEST_ENV_LINK } from './pages-common';
+import { GOAL_CREATED_DATA } from './pages-common';
 
 const { chromium } = require('playwright');
 const getTodayDateFormatted = (): string => {

--- a/page-objects/strengths-and-needs-pages.ts
+++ b/page-objects/strengths-and-needs-pages.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
+import { SP_TEST_ENV_LINK } from './pages-common';
 
 const { chromium } = require('playwright');
 
@@ -19,7 +20,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async validationErrorDisplays() {
-        await expect (newTabGlobal!.getByRole('alert')).toBeVisible();
+        await expect(newTabGlobal!.getByRole('alert')).toBeVisible();
     }
 
     // Accomodation
@@ -89,7 +90,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Accommodation ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Accommodation ✓' })).toBeVisible();
     }
 
     async clickAccomodationFactorsChangeLink() {
@@ -167,7 +168,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkEmploymentSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Employment and education ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Employment and education ✓' })).toBeVisible();
     }
 
     // Finances
@@ -217,7 +218,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkFinanceSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Finances ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Finances ✓' })).toBeVisible();
     }
 
     // Drug use
@@ -243,7 +244,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkDrugSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Drug use ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Drug use ✓' })).toBeVisible();
     }
 
     // Alcohol use
@@ -273,9 +274,9 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkAlcoholSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Alcohol use ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Alcohol use ✓' })).toBeVisible();
     }
-    
+
     // Health and wellbeing
 
     async clickHealthAndWellbeingLeftNavLink() {
@@ -290,7 +291,7 @@ export class StrengthsAndNeedsLandingPage {
         await newTabGlobal!.locator('#health_wellbeing_mental_health_condition').check();
     }
 
-    async tickPsychiatricTreatment(){
+    async tickPsychiatricTreatment() {
         await newTabGlobal!.locator('#health_wellbeing_psychiatric_treatment').check();
     }
 
@@ -347,7 +348,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkHealthSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Health and wellbeing ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Health and wellbeing ✓' })).toBeVisible();
     }
 
     // Personal relationships and community
@@ -362,7 +363,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async fillInInfoAboutChildren() {
         await newTabGlobal!.locator('#personal_relationships_community_children_details_yes_children_living_with_pop_details')
-        .fill('child 1');
+            .fill('child 1');
     }
 
     async tickPartnerImportantPeople() {
@@ -383,7 +384,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async enterChallengesInRelationshipsDetails() {
         await newTabGlobal!.locator('#personal_relationships_community_challenges_intimate_relationship')
-        .fill('person is comfortable addressing challenges.');
+            .fill('person is comfortable addressing challenges.');
     }
 
     async tickPositiveChildhood() {
@@ -411,7 +412,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkPersonalRelationshipsSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Personal relationships and community ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Personal relationships and community ✓' })).toBeVisible();
     }
 
     // Thinking, behaviours and attitudes
@@ -492,8 +493,8 @@ export class StrengthsAndNeedsLandingPage {
         await newTabGlobal!.locator('#thinking_behaviours_attitudes_criminal_behaviour').check();
     }
 
-    async tickThinkingBehaviourAlreadyMakingChanges(){
-    await newTabGlobal!.locator('#thinking_behaviours_attitudes_changes').check();
+    async tickThinkingBehaviourAlreadyMakingChanges() {
+        await newTabGlobal!.locator('#thinking_behaviours_attitudes_changes').check();
     }
 
     async tickThinkingBehaviourFactors() {
@@ -502,7 +503,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async fillProtectiveFactorsComment() {
         await newTabGlobal!.locator('#thinking_behaviours_attitudes_practitioner_analysis_strengths_or_protective_factors_yes_details')
-        .fill('Yes comment to thinking and behaviour protective factors');
+            .fill('Yes comment to thinking and behaviour protective factors');
     }
 
     async tickThinkingBehaviourRiskOfHarm() {
@@ -514,7 +515,7 @@ export class StrengthsAndNeedsLandingPage {
     }
 
     async checkThinkingBehaviourSectionCompleteIconDisplays() {
-        await expect (newTabGlobal!.getByRole('link', { name: 'Thinking, behaviours and attitudes ✓' })).toBeVisible();
+        await expect(newTabGlobal!.getByRole('link', { name: 'Thinking, behaviours and attitudes ✓' })).toBeVisible();
     }
 
     // Offence analysis
@@ -525,7 +526,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async fillBriefDescription() {
         await newTabGlobal!.locator('#offence_analysis_description_of_offence')
-        .fill('This is a brief description for the offence analysis.')
+            .fill('This is a brief description for the offence analysis.')
     }
 
     async tickWeapon() {
@@ -534,7 +535,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async fillReasonForOffence() {
         await newTabGlobal!.locator('#offence_analysis_reason')
-        .fill('This is why this took place.')
+            .fill('This is why this took place.')
     }
 
     async tickThrillSeeking() {
@@ -576,7 +577,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async fillPatternsOfOffending() {
         await newTabGlobal!.locator('#offence_analysis_patterns_of_offending')
-        .fill('There are no obvious patterns at this point.')
+            .fill('There are no obvious patterns at this point.')
     }
 
     async tickNotApplicableEscalation() {
@@ -589,7 +590,7 @@ export class StrengthsAndNeedsLandingPage {
 
     async fillDetailsAboutNoRiskOfSeriousHarm() {
         await newTabGlobal!.locator('#offence_analysis_risk_no_details')
-        .fill('No risk of serious harm.')
+            .fill('No risk of serious harm.')
     }
 
     async tickNoToPerpetratorOfDomestic() {
@@ -602,6 +603,24 @@ export class StrengthsAndNeedsLandingPage {
 
     async confirmUserIsOnOffenceAnalysisPage() {
         const heading = newTabGlobal!.getByRole('heading', { name: 'Offence analysis' });
-        await expect (heading).toBeVisible();
+        await expect(heading).toBeVisible();
+    }
+
+    async navigateToSPLink() {
+        await newTabGlobal!.goto(SP_TEST_ENV_LINK);
+    }
+
+    async clickAboutPageAfterNavigatingToSPWithoutOasysStep() {
+        
+        const aboutLink = await newTabGlobal!.getByRole('link', { name: 'About', exact: false })
+        await aboutLink.waitFor({ state: 'visible' });
+        await aboutLink.click();
+    }
+
+    async checkBannerDisplaysForIncompleteAssessment() {
+        await expect(newTabGlobal!.getByLabel('Warning'))
+            .toHaveCount(1);
+        await expect(newTabGlobal!.locator('h2.govuk-heading-m').first())
+            .toHaveText('Some areas have incomplete information');
     }
 }

--- a/page-objects/strengths-and-needs-pages.ts
+++ b/page-objects/strengths-and-needs-pages.ts
@@ -609,18 +609,4 @@ export class StrengthsAndNeedsLandingPage {
     async navigateToSPLink() {
         await newTabGlobal!.goto(SP_TEST_ENV_LINK);
     }
-
-    async clickAboutPageAfterNavigatingToSPWithoutOasysStep() {
-        
-        const aboutLink = await newTabGlobal!.getByRole('link', { name: 'About', exact: false })
-        await aboutLink.waitFor({ state: 'visible' });
-        await aboutLink.click();
-    }
-
-    async checkBannerDisplaysForIncompleteAssessment() {
-        await expect(newTabGlobal!.getByLabel('Warning'))
-            .toHaveCount(1);
-        await expect(newTabGlobal!.locator('h2.govuk-heading-m').first())
-            .toHaveText('Some areas have incomplete information');
-    }
 }

--- a/tests/12.userStartsSanThenSwitchesToSP.spec.ts
+++ b/tests/12.userStartsSanThenSwitchesToSP.spec.ts
@@ -51,13 +51,12 @@ test('User navigates to their About page from an incomplete San assessment', asy
   await strengthsAndNeedsLandingPage.navigateToSPLink();
 
   // Check navigation has taken place
-  await sentencePlanfromSanPage.checkPageTitle();
+  await sentencePlanfromSanPage.checkPageTitle()
 
   // Access About section
   await sentencePlanfromSanPage.clickAboutPageAfterNavigatingToSPWithoutOasysStep();
 
   // Check user info is displaying in the expected order on the about page
-  await strengthsAndNeedsLandingPage.checkBannerDisplaysForIncompleteAssessment();
-  await sentencePlanPage.checkInfoSectionNoFlagsListsCorrectOrder();
+  await sentencePlanfromSanPage.checkAboutPageDisplaysCorrectInfoForIncompleteSan();
   console.log('About page incomplete assessment without OASYS step verified');
 });

--- a/tests/12.userStartsSanThenSwitchesToSP.spec.ts
+++ b/tests/12.userStartsSanThenSwitchesToSP.spec.ts
@@ -56,7 +56,7 @@ test('User navigates to their About page from an incomplete San assessment', asy
   // Access About section
   await sentencePlanfromSanPage.clickAboutPageAfterNavigatingToSPWithoutOasysStep();
 
-  // Check user info is displaying in the expected order on the about page
+  // Check user info is displaying as expected on the about page
   await sentencePlanfromSanPage.checkAboutPageDisplaysCorrectInfoForIncompleteSan();
   console.log('About page incomplete assessment without OASYS step verified');
 });

--- a/tests/12.userStartsSanThenSwitchesToSP.spec.ts
+++ b/tests/12.userStartsSanThenSwitchesToSP.spec.ts
@@ -1,0 +1,63 @@
+import { test } from '@playwright/test';
+import { StubHomePage } from '../page-objects/stub-home-page';
+import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
+import { StrengthsAndNeedsLandingPage } from '../page-objects/strengths-and-needs-pages';
+import { SentencePlanfromSanPage } from '../page-objects/sentence-plan-page-from-san-page';
+import * as fs from 'fs'; // import file system module
+
+/* Note: this test feature will fail if the test data is wiped. 
+It relies on pre-existing PK with a completed SAN assessment. */
+test('User navigates to their About page from an incomplete San assessment', async ({ page }) => {
+
+  const stubHomePage = new StubHomePage(page);
+  const sentencePlanPage = new SentencePlanPage(page);
+  const strengthsAndNeedsLandingPage = new StrengthsAndNeedsLandingPage(page);
+  const sentencePlanfromSanPage = new SentencePlanfromSanPage(page);
+
+  // Navigate to the stub home page
+  await stubHomePage.goto();
+
+  // Check the title of the page is correct
+  await stubHomePage.checkPageTitle();
+
+  // Select sentence plan
+  await stubHomePage.selectStrenghtsAndNeeds();
+
+  // Simulate user interaction before clipboard usage
+  await stubHomePage.clickCriminogenicNeedsTab();
+
+  // Read json file and convert to string
+  // This json contains an incomplete SAN assessment PK
+  const filePath = './data/incompleteSanData.json'
+  const jsonData = fs.readFileSync(filePath, 'utf-8');
+
+  // Copy json data to clipboard
+  await page.evaluate(async (text) => { await navigator.clipboard.writeText(text);}, jsonData);
+  console.log('incomplete SAN data JSON file copied to clipboard')
+
+  // Paste configuration using UI
+  await stubHomePage.clickPasteConfigurationButton();
+
+  // Click create handover button
+  await stubHomePage.clickCreateHandoverButton();
+
+  // Click open button
+  await stubHomePage.clickOpenButton();
+
+  // Check the page title is correct
+  await strengthsAndNeedsLandingPage.checkPageTitle();
+
+  // Simulate navigating to SP without going via OASYS
+  await strengthsAndNeedsLandingPage.navigateToSPLink();
+
+  // Check navigation has taken place
+  await sentencePlanfromSanPage.checkPageTitle();
+
+  // Access About section
+  await sentencePlanfromSanPage.clickAboutPageAfterNavigatingToSPWithoutOasysStep();
+
+  // Check user info is displaying in the expected order on the about page
+  await strengthsAndNeedsLandingPage.checkBannerDisplaysForIncompleteAssessment();
+  await sentencePlanPage.checkInfoSectionNoFlagsListsCorrectOrder();
+  console.log('About page incomplete assessment without OASYS step verified');
+});


### PR DESCRIPTION
This PR is to start adding scenarios where a user performs tasks in SAN and switches straight into SP. This first scenario relies on test data where a user has started a SAN assessment by filling in the Accomodation and Employment and education sections and navigating to SP’s about page to check that data is there and correct. 

This also requires matching a JSON config  input so practicioner analysis is not overwritten by a random criminogenic needs dataset and the assertions on the about page remain relevant. 

Further scenarios will be added of a different nature in future work.