### PR TITLE
Arn 2611 update integration tests

### DIFF
--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -109,6 +109,10 @@ export class SentencePlanPage {
         await newTabGlobal!.locator('#date-selection-radio').check();
     }
 
+    async tickIn6Months() {
+        await newTabGlobal!.locator('#date-selection-radio-2').check();
+    }
+
     async tickFutureGoal() {
         await newTabGlobal!.locator('#start-working-goal-radio-2').check();
     }
@@ -492,7 +496,7 @@ export class SentencePlanPage {
     }
 
     async checkUpdateAgreePlanPageTitle() {
-        await expect (newTabGlobal!).toHaveTitle('Do they agree? - Sentence plan')
+        await expect(newTabGlobal!).toHaveTitle('Do they agree? - Sentence plan')
     }
 
     async clickBackLinkOnUpdateAgreePlanPage() {
@@ -509,5 +513,26 @@ export class SentencePlanPage {
 
     async clickSaveOnUpdateAgreePlanPage() {
         await newTabGlobal!.locator('#update-agree-plan-form > div.govuk-button-group > button').click();
+    }
+
+    async checkAgreementDataCorrectlyDisplaysInPlanHistory() {
+        await expect(newTabGlobal!.locator('#main-content > div > div > p:nth-child(2) > strong'))
+            .toContainText("Agreement updated");
+        await expect(newTabGlobal!.locator('#main-content > div > div > p:nth-child(3)'))
+            .toContainText("did not agree to this plan.");
+        await expect(newTabGlobal!.locator('#main-content > div > div > div:nth-child(4)'))
+            .toContainText("I do not agree");
+        await expect(newTabGlobal!.locator('#main-content > div > div > p:nth-child(6) > strong'))
+            .toContainText("Plan created");
+        await expect(newTabGlobal!.locator('#main-content > div > div > p:nth-child(7)'))
+            .toContainText("could not agree to this plan.");
+        await expect(newTabGlobal!.locator('#main-content > div > div > div:nth-child(8)'))
+            .toContainText("I could not answer");
+        await expect(newTabGlobal!.locator('#main-content > div > div > div.plan-additional-note'))
+            .toContainText("Test notes about agreeing the plan.");
+    }
+
+    async checkPlanHistoryPageTitle() {
+        await expect(newTabGlobal!).toHaveTitle('Plan history - Sentence plan')
     }
 }

--- a/page-objects/sentence-plan-pages.ts
+++ b/page-objects/sentence-plan-pages.ts
@@ -229,6 +229,24 @@ export class SentencePlanPage {
         await newTabGlobal!.locator('#agree-plan-radio').check();
     }
 
+    async tickNoIDoNotAgree() {
+        await newTabGlobal!.locator('#agree-plan-radio-2').check();
+    }
+
+    async fillInIDoNotAgreeDetails() {
+        await newTabGlobal!.locator('#does-not-agree-details')
+            .fill('I do not agree');
+    }
+
+    async tickCouldNotAnswer() {
+        await newTabGlobal!.locator('#agree-plan-radio-4').check();
+    }
+
+    async fillInCouldNotAnswerDetails() {
+        await newTabGlobal!.locator('#could-not-answer-details')
+            .fill('I could not answer');
+    }
+
     async fillInNotesAboutAgreeingPlan() {
         await newTabGlobal!.locator('#notes')
             .fill('Test notes about agreeing the plan.')
@@ -467,5 +485,29 @@ export class SentencePlanPage {
             const sortedPositions = [...positions].sort((a, b) => a - b);
             expect(positions).toEqual(sortedPositions);
         }
+    }
+
+    async clickUpdateAgreementLink() {
+        await newTabGlobal!.locator('#update-assessment-text > a').click();
+    }
+
+    async checkUpdateAgreePlanPageTitle() {
+        await expect (newTabGlobal!).toHaveTitle('Do they agree? - Sentence plan')
+    }
+
+    async clickBackLinkOnUpdateAgreePlanPage() {
+        await newTabGlobal!.getByRole('link', { name: 'Back', exact: true }).click();
+    }
+
+    async tickYesIAgreeOnUpdateAgreePlanPage() {
+        await newTabGlobal!.locator('#agree-plan-radio').check();
+    }
+
+    async tickNoIDoNotAgreeOnUpdateAgreePlanPage() {
+        await newTabGlobal!.locator('#agree-plan-radio-2').check();
+    }
+
+    async clickSaveOnUpdateAgreePlanPage() {
+        await newTabGlobal!.locator('#update-agree-plan-form > div.govuk-button-group > button').click();
     }
 }

--- a/tests/13.userUpdatesTheirGoalAgreement.spec.ts
+++ b/tests/13.userUpdatesTheirGoalAgreement.spec.ts
@@ -1,0 +1,93 @@
+import { test } from '@playwright/test';
+import { StubHomePage } from '../page-objects/stub-home-page';
+import { SentencePlanPage } from '../page-objects/sentence-plan-pages';
+import { Accessibility } from '../page-objects/accessibility';
+
+test('user updates their goal agreement', async ({ page }) => {
+
+  const stubHomePage = new StubHomePage(page);
+  const sentencePlanPage = new SentencePlanPage(page);
+  const accessibility = new Accessibility(page);
+
+  // Navigate to the stub home page
+  await stubHomePage.goto();
+
+  // Check the title of the page is correct
+  await stubHomePage.checkPageTitle();
+
+  // Select sentence plan
+  await stubHomePage.selectSentencePlan();
+
+  // Click create handover button
+  await stubHomePage.clickCreateHandoverButton();
+
+  // Click open button
+  await stubHomePage.clickOpenButton();
+
+  // Check the page title is correct
+  await sentencePlanPage.checkPageTitle();
+
+  // Check page has no accessiblity violations
+  await accessibility.shouldHaveNoAccessibilityViolations();
+
+  // Create an accomodation goal from top nav
+  await sentencePlanPage.clickCreateGoalButton();
+
+  // Check page has no accessiblity violations
+  await accessibility.shouldHaveNoAccessibilityViolations();
+
+  await sentencePlanPage.fillInGoalTitle();
+  await sentencePlanPage.tickGoalNotRelatedToAreaOfNeed();
+  await sentencePlanPage.tickCanStartWorkingOnGoalNow();
+  await sentencePlanPage.tickIn6Months();
+  await sentencePlanPage.clickAddSTeps();
+
+  await sentencePlanPage.checkAddSTepsToGoalPageTitle();
+
+  // Check page has no accessiblity violations
+  await accessibility.shouldHaveNoAccessibilityViolations();
+
+  await sentencePlanPage.selectProbationPracticioner();
+  await sentencePlanPage.fillInStepTitle();
+  await sentencePlanPage.clickSaveAndContinueButton();
+  console.log('Goal created');
+
+  // Agree plan - cannot answer
+  await sentencePlanPage.clickAgreePlanButton();
+  await sentencePlanPage.checkDoTheyAgreeToThisPLanPageTitle();
+
+  // Check page has no accessiblity violations
+  await accessibility.shouldHaveNoAccessibilityViolations();
+
+  await sentencePlanPage.tickCouldNotAnswer();
+  await sentencePlanPage.fillInCouldNotAnswerDetails();
+  await sentencePlanPage.fillInNotesAboutAgreeingPlan();
+  await sentencePlanPage.clickSaveButtonOnAgreePlanPage();
+  await sentencePlanPage.checkUserIsBAckOnSentencePlanLandingPage();
+
+  // Check page has no accessiblity violations
+  await accessibility.shouldHaveNoAccessibilityViolations();
+  console.log('Plan agreed - could not answer');
+
+  // Update agreement
+  await sentencePlanPage.clickUpdateAgreementLink();
+  await sentencePlanPage.checkUpdateAgreePlanPageTitle();
+
+  // Back out
+  await sentencePlanPage.clickBackLinkOnUpdateAgreePlanPage();
+  await sentencePlanPage.checkUserIsBAckOnSentencePlanLandingPage();
+
+  // Update agreement again
+  await sentencePlanPage.clickUpdateAgreementLink();
+  await sentencePlanPage.tickNoIDoNotAgree();
+  await sentencePlanPage.fillInIDoNotAgreeDetails();
+  await sentencePlanPage.clickSaveOnUpdateAgreePlanPage();
+  await sentencePlanPage.checkUserIsBAckOnSentencePlanLandingPage();
+  console.log('Agreement update saved')
+
+  // Check plan history is updated correctly
+  await sentencePlanPage.clickPlanHistoryTopNavLink();
+  await sentencePlanPage.checkPlanHistoryPageTitle();
+  await sentencePlanPage.checkAgreementDataCorrectlyDisplaysInPlanHistory();
+  console.log('Plan history data following agreement update verified')
+});


### PR DESCRIPTION
this PR is to add an automated journey to the integration tests where a user creates a goal, agrees to plan via the "Could not answer" route and updates the agreement then. checks the data is correct in plan history.

Work involved includes:

- Extension of sentence place page object class
- Addition of new test feature 