### PR TITLE
Arn 3135: add coordinator api tests

### DIFF
--- a/tests/arns-assessment-platform/dev/san/api/coordinator.spec.ts
+++ b/tests/arns-assessment-platform/dev/san/api/coordinator.spec.ts
@@ -5,9 +5,10 @@ import {
   entityVersions,
   getCoordinatorUrl,
   getVersionDate,
+  lock,
 } from '../../../../../utils/coordinator/coordinatorClient';
 import { updateAnswers } from '../../../../../utils/aap/sentencePlan/assessmentCommands';
-import { PreviousVersionsResponse } from '../../../../../utils/coordinator/coordinatorTypes';
+import { OasysCreateResponse, PreviousVersionsResponse } from '../../../../../utils/coordinator/coordinatorTypes';
 import { GroupCommandResult } from '../../../../../utils/aap/assessmentTypes';
 
 let apiContext: APIRequestContext;
@@ -42,7 +43,7 @@ let planVersion: number;
 
 test.beforeEach(async () => {
   sentencePlanId = await test.step('OAsys association', async () => {
-    const oasysResponse = await createOasysAssociation(coordinatorContext, crn);
+    const oasysResponse: OasysCreateResponse = await createOasysAssociation(coordinatorContext, crn);
     expect(oasysResponse).toBeTruthy();
 
     return oasysResponse.sentencePlanId;
@@ -55,11 +56,12 @@ test.beforeEach(async () => {
     expect(queryResponse).toHaveProperty('allVersions');
     expect(queryResponse.allVersions[today].planVersion.entityType).toBe('AAP_PLAN');
     expect(queryResponse.allVersions[today].planVersion.status).toBe('CREATED');
+
     return queryResponse.allVersions[today].planVersion.version;
   });
 });
 
-test('Coordinator get previous versions', async () => {
+test('Coordinator statuses', async () => {
   await test.step('Update answers', async () => {
     const updateResponse: GroupCommandResult = await updateAnswers(apiContext, sentencePlanId, crn);
 
@@ -73,5 +75,14 @@ test('Coordinator get previous versions', async () => {
     expect(queryResponse).toBeTruthy();
     expect(queryResponse.allVersions[today].planVersion.status).toBe('UNSIGNED');
     expect(queryResponse.allVersions[today].planVersion.version).not.toBe(planVersion);
+  });
+
+  await test.step('Lock plan', async () => {
+    await lock(coordinatorContext);
+
+    const queryResponse: PreviousVersionsResponse = await entityVersions(coordinatorContext, sentencePlanId);
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse.allVersions[today].planVersion.status).toBe('LOCKED');
   });
 });

--- a/tests/arns-assessment-platform/test/san/api/coordinator.counter-sign.spec.ts
+++ b/tests/arns-assessment-platform/test/san/api/coordinator.counter-sign.spec.ts
@@ -7,6 +7,7 @@ import {
   getAssociations,
   rollback,
   sign,
+  counterSign,
 } from '../../../../../utils/coordinator/coordinatorClient';
 import { PreviousVersionsResponse } from '../../../../../utils/coordinator/coordinatorTypes';
 
@@ -50,15 +51,25 @@ test.beforeEach(async () => {
   });
 
   versions = await test.step('Get previous versions', async () => {
-    const queryResponse: PreviousVersionsResponse = await entityVersions(coordinatorContext, association.assessmentId);
+    const queryResponse: PreviousVersionsResponse = await entityVersions(
+      coordinatorContext,
+      association.sentencePlanId
+    );
 
     expect(queryResponse).toBeTruthy();
     expect(queryResponse).toHaveProperty('allVersions');
-    expect(queryResponse.allVersions[today].planVersion.entityType).toBe('AAP_PLAN');
+    const planDate =
+      Object.entries(queryResponse.countersignedVersions).find(([, e]) => Object.keys(e).includes('planVersion')) ?? [];
+    const planLastUpdatedDate = planDate[0] ?? '';
+    expect(queryResponse.countersignedVersions[planLastUpdatedDate].planVersion.entityType).toBe('AAP_PLAN');
+    const assessmentDate =
+      Object.entries(queryResponse.allVersions).find(([, e]) => Object.keys(e).includes('assessmentVersion')) ?? [];
+    const assessmentLastUpdatedDate = assessmentDate[0] ?? '';
+    expect(queryResponse.allVersions[assessmentLastUpdatedDate].assessmentVersion.entityType).toBe('ASSESSMENT');
 
     return {
-      assessmentVersion: queryResponse.allVersions[today].assessmentVersion.version,
-      planVersion: queryResponse.allVersions[today].planVersion.version,
+      assessmentVersion: queryResponse.allVersions[assessmentLastUpdatedDate].assessmentVersion.version,
+      planVersion: queryResponse.countersignedVersions[planLastUpdatedDate].planVersion.version,
     };
   });
 });
@@ -74,9 +85,13 @@ test('Coordinator counter signing', async () => {
 
     expect(queryResponse).toBeTruthy();
     expect(queryResponse.allVersions[today].planVersion.status).toBe('ROLLED_BACK');
+    versions = {
+      assessmentVersion: queryResponse.allVersions[today].assessmentVersion.version,
+      planVersion: queryResponse.allVersions[today].planVersion.version,
+    };
   });
 
-  await test.step('Counter-sign plan', async () => {
+  await test.step('Sign plan', async () => {
     await sign(coordinatorContext, oasysPk, name, 'COUNTERSIGN');
 
     const queryResponse: PreviousVersionsResponse = await entityVersions(
@@ -86,5 +101,24 @@ test('Coordinator counter signing', async () => {
 
     expect(queryResponse).toBeTruthy();
     expect(queryResponse.allVersions[today].planVersion.status).toBe('AWAITING_COUNTERSIGN');
+  });
+
+  await test.step('Counter-sign plan', async () => {
+    await counterSign(
+      coordinatorContext,
+      oasysPk,
+      name,
+      'COUNTERSIGNED',
+      versions.assessmentVersion,
+      versions.planVersion
+    );
+
+    const queryResponse: PreviousVersionsResponse = await entityVersions(
+      coordinatorContext,
+      association.sentencePlanId
+    );
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse.countersignedVersions[today].planVersion.status).toBe('COUNTERSIGNED');
   });
 });

--- a/tests/arns-assessment-platform/test/san/api/coordinator.counter-sign.spec.ts
+++ b/tests/arns-assessment-platform/test/san/api/coordinator.counter-sign.spec.ts
@@ -5,15 +5,16 @@ import {
   getCoordinatorUrl,
   getVersionDate,
   getAssociations,
-  selfSign,
   rollback,
+  sign,
 } from '../../../../../utils/coordinator/coordinatorClient';
 import { PreviousVersionsResponse } from '../../../../../utils/coordinator/coordinatorTypes';
 
 let apiContext: APIRequestContext;
 let coordinatorContext: APIRequestContext;
 const today = getVersionDate();
-const oasysPk = '7282419';
+const oasysPk = '3173002';
+const name = 'Burley Zieme';
 
 test.beforeAll(async ({ playwright, baseURL }) => {
   apiContext = await playwright.request.newContext({
@@ -62,9 +63,9 @@ test.beforeEach(async () => {
   });
 });
 
-test('Coordinator self signing', async () => {
+test('Coordinator counter signing', async () => {
   await test.step('Rollback plan', async () => {
-    await rollback(coordinatorContext, oasysPk, versions.assessmentVersion, versions.planVersion);
+    await rollback(coordinatorContext, oasysPk, name, versions.assessmentVersion, versions.planVersion);
 
     const queryResponse: PreviousVersionsResponse = await entityVersions(
       coordinatorContext,
@@ -75,8 +76,8 @@ test('Coordinator self signing', async () => {
     expect(queryResponse.allVersions[today].planVersion.status).toBe('ROLLED_BACK');
   });
 
-  await test.step('Sign plan', async () => {
-    await selfSign(coordinatorContext, oasysPk);
+  await test.step('Counter-sign plan', async () => {
+    await sign(coordinatorContext, oasysPk, name, 'COUNTERSIGN');
 
     const queryResponse: PreviousVersionsResponse = await entityVersions(
       coordinatorContext,
@@ -84,6 +85,6 @@ test('Coordinator self signing', async () => {
     );
 
     expect(queryResponse).toBeTruthy();
-    expect(queryResponse.allVersions[today].planVersion.status).toBe('SELF_SIGNED');
+    expect(queryResponse.allVersions[today].planVersion.status).toBe('AWAITING_COUNTERSIGN');
   });
 });

--- a/tests/arns-assessment-platform/test/san/api/coordinator.self-sign.spec.ts
+++ b/tests/arns-assessment-platform/test/san/api/coordinator.self-sign.spec.ts
@@ -13,6 +13,7 @@ import { PreviousVersionsResponse } from '../../../../../utils/coordinator/coord
 let apiContext: APIRequestContext;
 let coordinatorContext: APIRequestContext;
 const today = getVersionDate();
+let lastUpdatedDate = '';
 const oasysPk = '7282419';
 const name = 'Brennon Mayer';
 
@@ -54,11 +55,14 @@ test.beforeEach(async () => {
 
     expect(queryResponse).toBeTruthy();
     expect(queryResponse).toHaveProperty('allVersions');
-    expect(queryResponse.allVersions[today].planVersion.entityType).toBe('AAP_PLAN');
+    const date =
+      Object.entries(queryResponse.allVersions).find(([, e]) => Object.keys(e).includes('planVersion')) ?? [];
+    lastUpdatedDate = date[0] ?? '';
+    expect(queryResponse.allVersions[lastUpdatedDate].planVersion.entityType).toBe('AAP_PLAN');
 
     return {
-      assessmentVersion: queryResponse.allVersions[today].assessmentVersion.version,
-      planVersion: queryResponse.allVersions[today].planVersion.version,
+      assessmentVersion: queryResponse.allVersions[lastUpdatedDate].assessmentVersion.version,
+      planVersion: queryResponse.allVersions[lastUpdatedDate].planVersion.version,
     };
   });
 });

--- a/tests/arns-assessment-platform/test/san/api/coordinator.self-sign.spec.ts
+++ b/tests/arns-assessment-platform/test/san/api/coordinator.self-sign.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { getBaseUrl, getToken } from '../../../../../utils/aapClient';
+import {
+  entityVersions,
+  getCoordinatorUrl,
+  getVersionDate,
+  getAssociations,
+  rollback,
+  sign,
+} from '../../../../../utils/coordinator/coordinatorClient';
+import { PreviousVersionsResponse } from '../../../../../utils/coordinator/coordinatorTypes';
+
+let apiContext: APIRequestContext;
+let coordinatorContext: APIRequestContext;
+const today = getVersionDate();
+const oasysPk = '7282419';
+const name = 'Brennon Mayer';
+
+test.beforeAll(async ({ playwright, baseURL }) => {
+  apiContext = await playwright.request.newContext({
+    baseURL: getBaseUrl(baseURL),
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${getToken()}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  coordinatorContext = await playwright.request.newContext({
+    baseURL: getCoordinatorUrl(baseURL),
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${getToken()}`,
+      'Content-Type': 'application/json',
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await apiContext.dispose();
+  await coordinatorContext.dispose();
+});
+
+let association: { sentencePlanId: string; assessmentId: string };
+let versions: { assessmentVersion: number; planVersion: number };
+
+test.beforeEach(async () => {
+  association = await test.step('OAsys association', async () => {
+    const oasysResponse = await getAssociations(coordinatorContext, oasysPk);
+    expect(oasysResponse).toBeTruthy();
+
+    return { sentencePlanId: oasysResponse.sentencePlanId, assessmentId: oasysResponse.sanAssessmentId };
+  });
+
+  versions = await test.step('Get previous versions', async () => {
+    const queryResponse: PreviousVersionsResponse = await entityVersions(coordinatorContext, association.assessmentId);
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse).toHaveProperty('allVersions');
+    expect(queryResponse.allVersions[today].planVersion.entityType).toBe('AAP_PLAN');
+
+    return {
+      assessmentVersion: queryResponse.allVersions[today].assessmentVersion.version,
+      planVersion: queryResponse.allVersions[today].planVersion.version,
+    };
+  });
+});
+
+test('Coordinator self signing', async () => {
+  await test.step('Rollback plan', async () => {
+    await rollback(coordinatorContext, oasysPk, name, versions.assessmentVersion, versions.planVersion);
+
+    const queryResponse: PreviousVersionsResponse = await entityVersions(
+      coordinatorContext,
+      association.sentencePlanId
+    );
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse.allVersions[today].planVersion.status).toBe('ROLLED_BACK');
+  });
+
+  await test.step('Sign plan', async () => {
+    await sign(coordinatorContext, oasysPk);
+
+    const queryResponse: PreviousVersionsResponse = await entityVersions(
+      coordinatorContext,
+      association.sentencePlanId
+    );
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse.allVersions[today].planVersion.status).toBe('SELF_SIGNED');
+  });
+});

--- a/tests/arns-assessment-platform/test/san/api/coordinator.spec.ts
+++ b/tests/arns-assessment-platform/test/san/api/coordinator.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { getBaseUrl, getToken } from '../../../../../utils/aapClient';
+import {
+  entityVersions,
+  getCoordinatorUrl,
+  getVersionDate,
+  getAssociations,
+  selfSign,
+  rollback,
+} from '../../../../../utils/coordinator/coordinatorClient';
+import { PreviousVersionsResponse } from '../../../../../utils/coordinator/coordinatorTypes';
+
+let apiContext: APIRequestContext;
+let coordinatorContext: APIRequestContext;
+const today = getVersionDate();
+const oasysPk = '7282419';
+
+test.beforeAll(async ({ playwright, baseURL }) => {
+  apiContext = await playwright.request.newContext({
+    baseURL: getBaseUrl(baseURL),
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${getToken()}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  coordinatorContext = await playwright.request.newContext({
+    baseURL: getCoordinatorUrl(baseURL),
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${getToken()}`,
+      'Content-Type': 'application/json',
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await apiContext.dispose();
+  await coordinatorContext.dispose();
+});
+
+let association: { sentencePlanId: string; assessmentId: string };
+let versions: { assessmentVersion: number; planVersion: number };
+
+test.beforeEach(async () => {
+  association = await test.step('OAsys association', async () => {
+    const oasysResponse = await getAssociations(coordinatorContext, oasysPk);
+    expect(oasysResponse).toBeTruthy();
+
+    return { sentencePlanId: oasysResponse.sentencePlanId, assessmentId: oasysResponse.sanAssessmentId };
+  });
+
+  versions = await test.step('Get previous versions', async () => {
+    const queryResponse: PreviousVersionsResponse = await entityVersions(coordinatorContext, association.assessmentId);
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse).toHaveProperty('allVersions');
+    expect(queryResponse.allVersions[today].planVersion.entityType).toBe('AAP_PLAN');
+
+    return {
+      assessmentVersion: queryResponse.allVersions[today].assessmentVersion.version,
+      planVersion: queryResponse.allVersions[today].planVersion.version,
+    };
+  });
+});
+
+test('Coordinator self signing', async () => {
+  await test.step('Rollback plan', async () => {
+    await rollback(coordinatorContext, oasysPk, versions.assessmentVersion, versions.planVersion);
+
+    const queryResponse: PreviousVersionsResponse = await entityVersions(
+      coordinatorContext,
+      association.sentencePlanId
+    );
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse.allVersions[today].planVersion.status).toBe('ROLLED_BACK');
+  });
+
+  await test.step('Sign plan', async () => {
+    await selfSign(coordinatorContext, oasysPk);
+
+    const queryResponse: PreviousVersionsResponse = await entityVersions(
+      coordinatorContext,
+      association.sentencePlanId
+    );
+
+    expect(queryResponse).toBeTruthy();
+    expect(queryResponse.allVersions[today].planVersion.status).toBe('SELF_SIGNED');
+  });
+});

--- a/utils/coordinator/coordinatorClient.ts
+++ b/utils/coordinator/coordinatorClient.ts
@@ -1,5 +1,12 @@
 import { APIRequestContext, APIResponse } from '@playwright/test';
-import { OasysCreateRequest, OasysCreateResponse, PreviousVersionsResponse, UserDetails } from './coordinatorTypes';
+import {
+  OasysCreateRequest,
+  OasysCreateResponse,
+  OasysRollbackRequest,
+  OasysSignRequest,
+  PreviousVersionsResponse,
+  UserDetails,
+} from './coordinatorTypes';
 
 export const getCoordinatorUrl = (baseUrl: string): string => {
   if (baseUrl.includes('test')) {
@@ -51,6 +58,16 @@ export const entityVersions = async (
   return await response.json();
 };
 
+export const getAssociations = async (request: APIRequestContext, oasysPk: string = '7282419') => {
+  const response: APIResponse = await request.get(`/oasys/${oasysPk}/associations`);
+
+  if (!response.ok()) {
+    throw new Error(`OASys Associations failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  return await response.json();
+};
+
 export const getVersionDate = (): string => {
   const today = new Date();
   return today.toISOString().split('T')[0];
@@ -66,7 +83,47 @@ export const lock = async (request: APIRequestContext) => {
 
   const response = await request.post(`/oasys/${oasysPk}/lock`, { data: userDetails });
   if (!response.ok()) {
-    throw new Error(`Oasys signing failed: ${response.status()} ${response.statusText()}`);
+    throw new Error(`Oasys lock failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  return await response.json();
+};
+
+export const selfSign = async (request: APIRequestContext, oasysPk: string) => {
+  const sign: OasysSignRequest = {
+    signType: 'SELF',
+    userDetails: {
+      id: oasysPk,
+      name: 'Brennon Mayer',
+    },
+  };
+
+  const response = await request.post(`/oasys/${oasysPk}/sign`, { data: sign });
+  if (!response.ok()) {
+    throw new Error(`Oasys self signing failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  return await response.json();
+};
+
+export const rollback = async (
+  request: APIRequestContext,
+  oasysPk: string,
+  sanVersionNumber?: number,
+  sentencePlanVersionNumber?: number
+) => {
+  const rollback: OasysRollbackRequest = {
+    sanVersionNumber: sanVersionNumber,
+    sentencePlanVersionNumber: sentencePlanVersionNumber,
+    userDetails: {
+      id: oasysPk,
+      name: 'Brennon Mayer',
+    },
+  };
+
+  const response = await request.post(`/oasys/${oasysPk}/rollback`, { data: rollback });
+  if (!response.ok()) {
+    throw new Error(`Oasys rollback failed: ${response.status()} ${response.statusText()}`);
   }
 
   return await response.json();

--- a/utils/coordinator/coordinatorClient.ts
+++ b/utils/coordinator/coordinatorClient.ts
@@ -5,6 +5,7 @@ import {
   OasysRollbackRequest,
   OasysSignRequest,
   PreviousVersionsResponse,
+  SignType,
   UserDetails,
 } from './coordinatorTypes';
 
@@ -89,12 +90,17 @@ export const lock = async (request: APIRequestContext) => {
   return await response.json();
 };
 
-export const selfSign = async (request: APIRequestContext, oasysPk: string) => {
+export const sign = async (
+  request: APIRequestContext,
+  oasysPk: string,
+  name: string = 'Brennon Mayer',
+  signType: SignType = 'SELF'
+) => {
   const sign: OasysSignRequest = {
-    signType: 'SELF',
+    signType: signType,
     userDetails: {
       id: oasysPk,
-      name: 'Brennon Mayer',
+      name: name,
     },
   };
 
@@ -109,6 +115,7 @@ export const selfSign = async (request: APIRequestContext, oasysPk: string) => {
 export const rollback = async (
   request: APIRequestContext,
   oasysPk: string,
+  name: string = 'Brennon Mayer',
   sanVersionNumber?: number,
   sentencePlanVersionNumber?: number
 ) => {
@@ -117,7 +124,7 @@ export const rollback = async (
     sentencePlanVersionNumber: sentencePlanVersionNumber,
     userDetails: {
       id: oasysPk,
-      name: 'Brennon Mayer',
+      name: name,
     },
   };
 

--- a/utils/coordinator/coordinatorClient.ts
+++ b/utils/coordinator/coordinatorClient.ts
@@ -1,9 +1,11 @@
 import { APIRequestContext, APIResponse } from '@playwright/test';
 import {
+  OasysCounterSignRequest,
   OasysCreateRequest,
   OasysCreateResponse,
   OasysRollbackRequest,
   OasysSignRequest,
+  Outcome,
   PreviousVersionsResponse,
   SignType,
   UserDetails,
@@ -112,6 +114,32 @@ export const sign = async (
   return await response.json();
 };
 
+export const counterSign = async (
+  request: APIRequestContext,
+  oasysPk: string,
+  name: string = 'Brennon Mayer',
+  outcome: Outcome = 'COUNTERSIGNED',
+  sanVersionNumber?: number,
+  sentencePlanVersionNumber?: number
+) => {
+  const sign: OasysCounterSignRequest = {
+    outcome: outcome,
+    sanVersionNumber: sanVersionNumber,
+    sentencePlanVersionNumber: sentencePlanVersionNumber,
+    userDetails: {
+      id: oasysPk,
+      name: name,
+    },
+  };
+
+  const response = await request.post(`/oasys/${oasysPk}/counter-sign`, { data: sign });
+  if (!response.ok()) {
+    throw new Error(`Oasys self signing failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  return await response.json();
+};
+
 export const rollback = async (
   request: APIRequestContext,
   oasysPk: string,
@@ -128,10 +156,14 @@ export const rollback = async (
     },
   };
 
-  const response = await request.post(`/oasys/${oasysPk}/rollback`, { data: rollback });
-  if (!response.ok()) {
-    throw new Error(`Oasys rollback failed: ${response.status()} ${response.statusText()}`);
-  }
+  try {
+    const response = await request.post(`/oasys/${oasysPk}/rollback`, { data: rollback });
+    if (!response.ok()) {
+      throw new Error(`Oasys rollback failed: ${response.status()} ${response.statusText()}`);
+    }
 
-  return await response.json();
+    return await response.json();
+  } catch {
+    return {};
+  }
 };

--- a/utils/coordinator/coordinatorClient.ts
+++ b/utils/coordinator/coordinatorClient.ts
@@ -1,5 +1,5 @@
 import { APIRequestContext, APIResponse } from '@playwright/test';
-import { OasysCreateRequest, OasysCreateResponse, PreviousVersionsResponse } from './coordinatorTypes';
+import { OasysCreateRequest, OasysCreateResponse, PreviousVersionsResponse, UserDetails } from './coordinatorTypes';
 
 export const getCoordinatorUrl = (baseUrl: string): string => {
   if (baseUrl.includes('test')) {
@@ -9,6 +9,7 @@ export const getCoordinatorUrl = (baseUrl: string): string => {
 };
 
 export const oasysPk = Math.floor(Math.random() * 1000000000).toString();
+export const name = 'Test';
 
 export const createOasysAssociation = async (request: APIRequestContext, crn: string): Promise<OasysCreateResponse> => {
   const create: OasysCreateRequest = {
@@ -17,7 +18,7 @@ export const createOasysAssociation = async (request: APIRequestContext, crn: st
     assessmentType: 'SAN_SP',
     userDetails: {
       id: oasysPk,
-      name: 'Test',
+      name: name,
       location: 'PRISON',
     },
     subjectDetails: {
@@ -53,4 +54,20 @@ export const entityVersions = async (
 export const getVersionDate = (): string => {
   const today = new Date();
   return today.toISOString().split('T')[0];
+};
+
+export const lock = async (request: APIRequestContext) => {
+  const userDetails: UserDetails = {
+    userDetails: {
+      id: oasysPk,
+      name: name,
+    },
+  };
+
+  const response = await request.post(`/oasys/${oasysPk}/lock`, { data: userDetails });
+  if (!response.ok()) {
+    throw new Error(`Oasys signing failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  return await response.json();
 };

--- a/utils/coordinator/coordinatorTypes.ts
+++ b/utils/coordinator/coordinatorTypes.ts
@@ -71,6 +71,15 @@ export interface OasysSignRequest {
   userDetails: OasysUserDetails;
 }
 
+export type Outcome = 'COUNTERSIGNED' | 'AWAITING_DOUBLE_COUNTERSIGN' | 'DOUBLE_COUNTERSIGNED' | 'REJECTED';
+
+export interface OasysCounterSignRequest {
+  sanVersionNumber?: number;
+  sentencePlanVersionNumber?: number;
+  outcome: Outcome;
+  userDetails: OasysUserDetails;
+}
+
 export interface OasysRollbackRequest {
   sanVersionNumber?: number;
   sentencePlanVersionNumber?: number;

--- a/utils/coordinator/coordinatorTypes.ts
+++ b/utils/coordinator/coordinatorTypes.ts
@@ -4,6 +4,10 @@ export type AssessmentType = 'SAN_SP' | 'SP';
 
 export type UserLocation = 'PRISON' | 'COMMUNITY';
 
+export interface UserDetails {
+  userDetails: OasysUserDetails;
+}
+
 export interface OasysUserDetails {
   id: string;
   name: string;
@@ -57,4 +61,11 @@ export interface OasysCreateResponse {
   sanAssessmentVersion: number;
   sentencePlanId: string;
   sentencePlanVersion: number;
+}
+
+export type SignType = 'SELF' | 'COUNTERSIGN';
+
+export interface OasysSignRequest {
+  signType: SignType;
+  userDetails: OasysUserDetails;
 }

--- a/utils/coordinator/coordinatorTypes.ts
+++ b/utils/coordinator/coordinatorTypes.ts
@@ -1,6 +1,6 @@
 export type PlanType = 'INITIAL' | 'REVIEW' | 'UPW' | 'PSR_OUTLINE';
 
-export type AssessmentType = 'SAN_SP' | 'SP';
+export type AssessmentType = 'SAN_SP' | 'SP' | 'SAN';
 
 export type UserLocation = 'PRISON' | 'COMMUNITY';
 
@@ -12,6 +12,7 @@ export interface OasysUserDetails {
   id: string;
   name: string;
   location?: UserLocation;
+  type?: AssessmentType;
 }
 
 export interface SubjectDetails {
@@ -67,5 +68,11 @@ export type SignType = 'SELF' | 'COUNTERSIGN';
 
 export interface OasysSignRequest {
   signType: SignType;
+  userDetails: OasysUserDetails;
+}
+
+export interface OasysRollbackRequest {
+  sanVersionNumber?: number;
+  sentencePlanVersionNumber?: number;
   userDetails: OasysUserDetails;
 }


### PR DESCRIPTION
Endpoints:
- Lock
- Sign
- Counter-sign
(Create / Rollback included for setup / cleanup within tests)

Sign & Counter-sign currently only work on Test environment (As the SAN assessment needs to be in a complete state).