### PR TITLE
ci: Run on chromium & edge

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --only-shell
       - name: Install Edge
-        run: npx playwright install --with-deps msedge
+        run: npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
         run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
       - name: Install Playwright
         run: npx playwright install --only-shell
+      - name: Install Edge
+        run: npx playwright install --with-deps msedge
       - name: Run Playwright tests
         id: playwright-tests
         run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright
-        run: npx playwright install
-      # - name: Install Edge
-      #   run: npx playwright install msedge
+        run: npx playwright install --only-shell
+      - name: Install Edge
+        run: npx playwright install msedge-beta
       - name: Run Playwright tests
         id: playwright-tests
         run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,13 +29,14 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
+      - run: mkdir -p /tmp/pw-browsers
       - name: Install Playwright
-        run: PLAYWRIGHT_BROWSERS_PATH=/usr/pw-browsers npx playwright install --only-shell
+        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install --only-shell
       - name: Install Edge
-        run: PLAYWRIGHT_BROWSERS_PATH=/usr/pw-browsers npx playwright install msedge
+        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
-        run: PLAYWRIGHT_BROWSERS_PATH=/usr/pw-browsers npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
+        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
         env:
           ORACLE_DB_USER: ${{ secrets.ORACLE_DB_USER }}
           ORACLE_DB_PASSWORD: ${{ secrets.ORACLE_DB_PASSWORD }}
@@ -53,7 +54,7 @@ jobs:
           MPOP_USERNAME: ${{ secrets.E2E_MPOP_USERNAME }}
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
-          PLAYWRIGHT_BROWSERS_PATH: /usr/pw-browsers
+          PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
 
       - name: Publish Test Summary
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,9 +31,9 @@ jobs:
         run: npm ci
       - run: mkdir -p /tmp/pw-browsers
       - name: Install Playwright
-        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install --only-shell
-      - name: Install Edge
-        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install msedge
+        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install
+      # - name: Install Edge
+      #   run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
         run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npm run ${{ inputs.environment }}:${{ inputs.source }}:ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,14 +29,13 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
-      - run: mkdir -p /tmp/pw-browsers
       - name: Install Playwright
-        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install
-      # - name: Install Edge
-      #   run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install msedge
+        run: PLAYWRIGHT_BROWSERS_PATH=/opt/playwright npx playwright install chromium --no-shell
+      - name: Install Edge
+        run: PLAYWRIGHT_BROWSERS_PATH=/opt/playwright npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
-        run: PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
+        run: PLAYWRIGHT_BROWSERS_PATH=/opt/playwright npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
         env:
           ORACLE_DB_USER: ${{ secrets.ORACLE_DB_USER }}
           ORACLE_DB_PASSWORD: ${{ secrets.ORACLE_DB_PASSWORD }}
@@ -54,7 +53,7 @@ jobs:
           MPOP_USERNAME: ${{ secrets.E2E_MPOP_USERNAME }}
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
-          PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
+          PLAYWRIGHT_BROWSERS_PATH: /opt/playwright
 
       - name: Publish Test Summary
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright
-        run: npx playwright install --only-shell
-      - name: Install Edge
-        run: npx playwright install msedge
+        run: npx playwright install
+      # - name: Install Edge
+      #   run: npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
         run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
@@ -68,24 +68,24 @@ jobs:
           path: |
             test-results/**/*
       
-      - name: Slack notification
-        if: failure()
-        uses: slackapi/slack-github-action@v3.0.3
-        env:
-          SLACK_CHANNEL: ${{ inputs.channel_id }}
-          REPO_NAME: ${{ github.repository }}
-          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "${{ env.SLACK_CHANNEL }}",
-              "text": "🚨 ${{ inputs.environment }} - Integration Playwright Tests Failed",
-              "attachments": [
-               {
-                 "color": "#FF0000",
-                 "text": ":x: *Playwright Integration tests notification*\nWorkflow failed on ${{ inputs.environment }} environment for ${{ env.REPO_NAME }}"
-                }
-              ]
-            }
+      # - name: Slack notification
+      #   if: failure()
+      #   uses: slackapi/slack-github-action@v3.0.3
+      #   env:
+      #     SLACK_CHANNEL: ${{ inputs.channel_id }}
+      #     REPO_NAME: ${{ github.repository }}
+      #     SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
+      #   with:
+      #     method: chat.postMessage
+      #     token: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
+      #     payload: |
+      #       {
+      #         "channel": "${{ env.SLACK_CHANNEL }}",
+      #         "text": "🚨 ${{ inputs.environment }} - Integration Playwright Tests Failed",
+      #         "attachments": [
+      #          {
+      #            "color": "#FF0000",
+      #            "text": ":x: *Playwright Integration tests notification*\nWorkflow failed on ${{ inputs.environment }} environment for ${{ env.REPO_NAME }}"
+      #           }
+      #         ]
+      #       }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -64,24 +64,24 @@ jobs:
           path: |
             test-results/**/*
       
-      # - name: Slack notification
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v3.0.3
-      #   env:
-      #     SLACK_CHANNEL: ${{ inputs.channel_id }}
-      #     REPO_NAME: ${{ github.repository }}
-      #     SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
-      #   with:
-      #     method: chat.postMessage
-      #     token: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
-      #     payload: |
-      #       {
-      #         "channel": "${{ env.SLACK_CHANNEL }}",
-      #         "text": "🚨 ${{ inputs.environment }} - Integration Playwright Tests Failed",
-      #         "attachments": [
-      #          {
-      #            "color": "#FF0000",
-      #            "text": ":x: *Playwright Integration tests notification*\nWorkflow failed on ${{ inputs.environment }} environment for ${{ env.REPO_NAME }}"
-      #           }
-      #         ]
-      #       }
+      - name: Slack notification
+        if: failure()
+        uses: slackapi/slack-github-action@v3.0.3
+        env:
+          SLACK_CHANNEL: ${{ inputs.channel_id }}
+          REPO_NAME: ${{ github.repository }}
+          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "🚨 ${{ inputs.environment }} - Integration Playwright Tests Failed",
+              "attachments": [
+               {
+                 "color": "#FF0000",
+                 "text": ":x: *Playwright Integration tests notification*\nWorkflow failed on ${{ inputs.environment }} environment for ${{ env.REPO_NAME }}"
+                }
+              ]
+            }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --only-shell
       - name: Install Edge
-        run: npx playwright install msedge-beta
+        run: npx playwright install msedge-dev
       - name: Run Playwright tests
         id: playwright-tests
         run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright
-        run: PLAYWRIGHT_BROWSERS_PATH=/opt/playwright npx playwright install chromium --no-shell
+        run: npx playwright install chromium --no-shell
       - name: Install Edge
-        run: PLAYWRIGHT_BROWSERS_PATH=/opt/playwright npx playwright install msedge
+        run: npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
-        run: PLAYWRIGHT_BROWSERS_PATH=/opt/playwright npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
+        run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
         env:
           ORACLE_DB_USER: ${{ secrets.ORACLE_DB_USER }}
           ORACLE_DB_PASSWORD: ${{ secrets.ORACLE_DB_PASSWORD }}
@@ -53,7 +53,6 @@ jobs:
           MPOP_USERNAME: ${{ secrets.E2E_MPOP_USERNAME }}
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
-          PLAYWRIGHT_BROWSERS_PATH: /opt/playwright
 
       - name: Publish Test Summary
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,10 +29,6 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
-      - name: Install Playwright
-        run: npx playwright install chromium --no-shell
-      - name: Install Edge
-        run: npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
         run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright
-        run: npx playwright install --only-shell
+        run: PLAYWRIGHT_BROWSERS_PATH=/usr/pw-browsers npx playwright install --only-shell
       - name: Install Edge
-        run: npx playwright install msedge-dev
+        run: PLAYWRIGHT_BROWSERS_PATH=/usr/pw-browsers npx playwright install msedge
       - name: Run Playwright tests
         id: playwright-tests
-        run: npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
+        run: PLAYWRIGHT_BROWSERS_PATH=/usr/pw-browsers npm run ${{ inputs.environment }}:${{ inputs.source }}:ci
         env:
           ORACLE_DB_USER: ${{ secrets.ORACLE_DB_USER }}
           ORACLE_DB_PASSWORD: ${{ secrets.ORACLE_DB_PASSWORD }}
@@ -53,6 +53,7 @@ jobs:
           MPOP_USERNAME: ${{ secrets.E2E_MPOP_USERNAME }}
           DELIUS_USERNAME: ${{ secrets.E2E_DELIUS_USERNAME }}
           DELIUS_PASSWORD: ${{ secrets.E2E_DELIUS_PASSWORD }}
+          PLAYWRIGHT_BROWSERS_PATH: /usr/pw-browsers
 
       - name: Publish Test Summary
         uses: ctrf-io/github-test-reporter@v1

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,32 +46,32 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
       testDir: './tests/arns-assessment-platform/dev',
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: './tests/arns-assessment-platform/dev',
     },
     {
       name: 'chromium_aap',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
       testDir: './tests/arns-assessment-platform/dev/aap',
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: './tests/arns-assessment-platform/dev/aap',
     },
     {
       name: 'chromium_san',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
       testDir: '../tests/arns-assessment-platform/dev/san',
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: '../tests/arns-assessment-platform/dev/san',
     },
   ],

--- a/playwright.test.config.ts
+++ b/playwright.test.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: './tests/arns-assessment-platform',
     },
     {
@@ -59,7 +59,7 @@ export default defineConfig({
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
@@ -69,7 +69,7 @@ export default defineConfig({
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: '*san/**/*.spec.ts',
     },
   ],

--- a/playwright.test.config.ts
+++ b/playwright.test.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge-dev' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: './tests/arns-assessment-platform',
     },
     {
@@ -61,7 +61,7 @@ export default defineConfig({
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'], channel: 'msedge-dev' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
@@ -71,7 +71,7 @@ export default defineConfig({
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'], channel: 'msedge-dev' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: '*san/**/*.spec.ts',
     },
   ],

--- a/playwright.test.config.ts
+++ b/playwright.test.config.ts
@@ -46,32 +46,32 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
       testDir: './tests/arns-assessment-platform',
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: { ...devices['Desktop Edge'] },
       testDir: './tests/arns-assessment-platform',
     },
     {
       name: 'chromium_aap',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: { ...devices['Desktop Edge'] },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
       name: 'chromium_san',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
       testMatch: '*san/**/*.spec.ts',
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: { ...devices['Desktop Edge'] },
       testDir: '*san/**/*.spec.ts',
     },
   ],

--- a/playwright.test.config.ts
+++ b/playwright.test.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: './tests/arns-assessment-platform',
     },
     {
@@ -61,7 +61,7 @@ export default defineConfig({
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
@@ -71,7 +71,7 @@ export default defineConfig({
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'] },
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
       testDir: '*san/**/*.spec.ts',
     },
   ],

--- a/playwright.test.config.ts
+++ b/playwright.test.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge-beta' },
       testDir: './tests/arns-assessment-platform',
     },
     {
@@ -61,7 +61,7 @@ export default defineConfig({
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge-beta' },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
@@ -71,7 +71,7 @@ export default defineConfig({
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge-beta' },
       testDir: '*san/**/*.spec.ts',
     },
   ],

--- a/playwright.test.config.ts
+++ b/playwright.test.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge-beta' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge-dev' },
       testDir: './tests/arns-assessment-platform',
     },
     {
@@ -61,7 +61,7 @@ export default defineConfig({
     },
     {
       name: 'edge_aap',
-      use: { ...devices['Desktop Edge'], channel: 'msedge-beta' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge-dev' },
       testMatch: '*aap/**/*.spec.ts',
     },
     {
@@ -71,7 +71,7 @@ export default defineConfig({
     },
     {
       name: 'edge_san',
-      use: { ...devices['Desktop Edge'], channel: 'msedge-beta' },
+      use: { ...devices['Desktop Edge'], channel: 'msedge-dev' },
       testDir: '*san/**/*.spec.ts',
     },
   ],


### PR DESCRIPTION
New [Chromium](https://playwright.dev/docs/browsers#chromium-new-headless-mode) headless
[Edge browser](https://github.com/ministryofjustice/hmpps-github-actions-runner/pull/153) now installed on the runners

Successful [Run](https://github.com/ministryofjustice/hmpps-arns-integrations-test-playwright/actions/runs/26040121118)
