### PR TITLE
Refactor assessmentView.spec.ts

### DIFF
--- a/tests/arns-assessment-platform/dev/arns/20.AssessmentView.spec.ts
+++ b/tests/arns-assessment-platform/dev/arns/20.AssessmentView.spec.ts
@@ -5,11 +5,16 @@ let apiContext: APIRequestContext;
 const TEST_CRN = 'C912155';
 
 function validateStepStructure(step: AssessmentStep) {
-  expect(step.description).toEqual(expect.any(String));
-  expect(step.status).toEqual(expect.any(String));
-  expect(step.actor).toEqual(expect.any(String));
-  expect(step.statusDate).toEqual(expect.any(String));
-  expect(isNaN(Date.parse(step.statusDate))).toBeFalsy();
+  expect(step).toEqual(
+    expect.objectContaining({
+      description: expect.any(String),
+      status: expect.any(String),
+      actor: expect.any(String),
+      statusDate: expect.any(String),
+    })
+  );
+
+  expect(new Date(step.statusDate).toString()).not.toBe('Invalid Date');
 }
 
 test.beforeAll(async ({ playwright, baseURL }) => {
@@ -34,23 +39,31 @@ test('view ARNS assessment successfully returns correct data structure', async (
 
   const assessment = responseBody[0];
 
-  expect(assessment.crn).toEqual(TEST_CRN);
-
-  expect(assessment.nomis).toBeNull();
-  expect(assessment.planStatus).toEqual(expect.any(String));
-
-  expect(Array.isArray(assessment.goals)).toBeTruthy();
+  expect(assessment).toEqual(
+    expect.objectContaining({
+      crn: TEST_CRN,
+      nomis: null,
+      planStatus: expect.any(String),
+      goals: expect.any(Array),
+    })
+  );
 
   for (const goal of assessment.goals) {
-    expect(goal.titleLength).toEqual(expect.any(Number));
-    expect(goal.titleHash).toEqual(expect.any(String));
-    expect(goal.areaOfNeed).toEqual(expect.any(String));
-    expect(goal.goalStatus).toEqual(expect.any(String));
+    expect(goal).toEqual(
+      expect.objectContaining({
+        titleLength: expect.any(Number),
+        titleHash: expect.any(String),
+        areaOfNeed: expect.any(String),
+        goalStatus: expect.any(String),
+        relatedAreasOfNeed: expect.any(Array),
+        steps: expect.any(Array),
+      })
+    );
 
-    expect(goal.targetDate === null || typeof goal.targetDate === 'string').toBeTruthy();
-
-    expect(Array.isArray(goal.relatedAreasOfNeed)).toBeTruthy();
-    expect(Array.isArray(goal.steps)).toBeTruthy();
+    expect(
+      goal.targetDate === null || typeof goal.targetDate === 'string',
+      `Type Error: Expected goal.targetDate to be 'string' or 'null', but received type '${typeof goal.targetDate}' with value: ${goal.targetDate}`
+    ).toBeTruthy();
 
     for (const step of goal.steps) {
       validateStepStructure(step);


### PR DESCRIPTION
A few things I want to improve in that test feature to make it more readable
 and easier to debug.

- move expect(Array.isArray(goal.relatedAreasOfNeed)) directly into objectContaining
- improve debugging
- improve statusDate assertion (currently double-negative, not great to read)